### PR TITLE
Simple bash tab completion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,10 @@ This is the `notify` module in action.
 ## Alfred files getting too large?
 You can break up your alfred files in multiple ways. The following are glob patterns that can be used:`/alfred.yml`, `/.alfred/*alfred.yml`, `/alfred/*alfred.yml`. As an example, you can create a directory called `alfred` or `.alfred` or just create mutliple alfred files.
 
+## Tab completion
+
+Copy the included `alfred.completion.sh` to `/etc/bash_completion.d/`, or source it in your `~/.profile` file.
+
 ## Testing
 You might say I've cheated the testing route by only scraping the output. You'd be right.
 

--- a/alfred.completion.sh
+++ b/alfred.completion.sh
@@ -1,0 +1,13 @@
+# Bash completion for alfred
+
+_alfred()
+{
+    local cur prev tokens
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    tokens="$(alfred | grep '^\[' | cut -d ' ' -f 1 | tr -d '[]')"
+
+    COMPREPLY=( $(compgen -W "${tokens}" -- ${cur}) )
+}
+complete -F _alfred alfred


### PR DESCRIPTION
Does a fairly hacky parse of the default `alfred` output to discard brackets and summary text.

Would be nicer with a `alfred --show-tasks` that didn't require string munging.