### PR TITLE
Fix index out of range fail when calling module (eg docker:)

### DIFF
--- a/alfred/alfred.go
+++ b/alfred/alfred.go
@@ -196,7 +196,7 @@ func (a *Alfred) runTask(task string, args []string, formatted bool) bool {
 		// Go through each of the modules ...
 		// before command, docker stop for example
 		for module, cmd := range copyOfTask.Modules {
-			if !copyOfTask.RunCommand(args[0]+" "+a.remote.ModulePath(module)+" "+cmd, task, formatted) {
+			if !copyOfTask.RunCommand(a.args[0]+" "+a.remote.ModulePath(module)+" "+cmd, task, formatted) {
 				// It failed :(
 				taskok = false
 				break


### PR DESCRIPTION
Module RunCommand is using local `args` (empty) instead of `a.args` (ie `os.Args`) for `[0]`

This makes @bryan-lott sad.

![](https://media0.giphy.com/media/5PSPV1ucLX31u/giphy.gif)
![](https://media3.giphy.com/media/skZDiwYddrFFm/giphy.gif)
![](https://media0.giphy.com/media/9xjEqVaPdFLpe/giphy.gif)
