### PR TITLE
trim whitespace before parsing multitaask

### DIFF
--- a/alfred/task.go
+++ b/alfred/task.go
@@ -108,6 +108,7 @@ func (t *Task) Aliases() []string {
 
 //TaskGroup takes in a string(bleh(1234) whatever(bleh, woot)) and returns the values and args
 func (t *Task) TaskGroup(tasks string, args []string) []TaskDefinition {
+	tasks = strings.TrimSpace(tasks)
 	results := make([]TaskDefinition, 0)
 	if tasks == "" {
 		// If there is nothing, then there is nothing to report


### PR DESCRIPTION
`alfred.yml` like

```
build:
    summary: build something
    multitask: >
        this
        that
        the.other.thing

blah:
```

would retain the new-line char on the end of `the.other.thing`, making it fail the `isValidTask()` test.

![](https://media.giphy.com/media/eR6Swb49vkbK0/giphy.gif)

it's been a long day