### PR TITLE
Allow the use of templates within the setup block

### DIFF
--- a/alfred/alfred.go
+++ b/alfred/alfred.go
@@ -138,6 +138,16 @@ func (a *Alfred) runTask(task string, args []string, formatted bool) bool {
 
 	// Infinite loop Used for the every command
 	for {
+
+		// Lets prep it, and if it's bunk, lets see if we can pump out it's usage
+                // We'll prepare it before running setup tasks in case we want to pass templated
+                // params to setup
+		if !copyOfTask.Prepare(args, a.Vars) {
+			say(task+":error", "Missing argument(s).")
+			// No need in going on, programmer error
+			os.Exit(1)
+		}
+
 		// Run our setup tasks
 		for _, taskDefinition := range copyOfTask.TaskGroup(copyOfTask.Setup, args) {
 			if !a.runTask(taskDefinition.Name, taskDefinition.Params, formatted) {
@@ -151,13 +161,6 @@ func (a *Alfred) runTask(task string, args []string, formatted bool) bool {
 		err := os.Chdir(a.dir)
 		if err != nil {
 			fmt.Println(err.Error())
-		}
-
-		// Lets prep it, and if it's bunk, lets see if we can pump out it's usage
-		if !copyOfTask.Prepare(args, a.Vars) {
-			say(task+":error", "Missing argument(s).")
-			// No need in going on, programmer error
-			os.Exit(1)
 		}
 
 		// Lets change the directory if set
@@ -212,7 +215,7 @@ func (a *Alfred) runTask(task string, args []string, formatted bool) bool {
 
 		// Register task output
 		if copyOfTask.Register != "" && copyOfTask.Command != "" {
-			if (a.Vars == nil) {
+			if a.Vars == nil {
 				a.Vars = make(map[string]string)
 			}
 			a.Vars[copyOfTask.Register] = copyOfTask.Exec(copyOfTask.Command)

--- a/alfred/task.go
+++ b/alfred/task.go
@@ -401,6 +401,11 @@ func (t *Task) Prepare(args []string, vars map[string]string) bool {
 		return false
 	}
 
+	if setupOk, setupTranslated := t.template(t.Setup); setupOk {
+		t.Setup = setupTranslated
+	} else {
+		return false
+	}
 	// if we made it here, then we are good to go
 	return true
 }
@@ -413,5 +418,6 @@ func (t *Task) template(translate string) (bool, string) {
 	if err == nil {
 		return true, b.String()
 	}
+
 	return false, translate
 }

--- a/alfred_test.go
+++ b/alfred_test.go
@@ -344,3 +344,11 @@ func TestExample(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestSetupTemplate(t *testing.T) {
+	sut, _ := run("alfred fourty.five hello world!", t)
+	if !strings.Contains(sut, "hello world!") {
+		t.Logf("Expecting 'hello world!' to be returned")
+		t.FailNow()
+	}
+}

--- a/examples/demo-everything/.alfred/part-two.alfred.yml
+++ b/examples/demo-everything/.alfred/part-two.alfred.yml
@@ -25,3 +25,8 @@ fourty.three:
 fourty.four:
     summary: A task with two params
     command: echo {{ index .Args 0 }} {{ index .Args 1 }}
+
+fourty.five:
+    summary: Call a setup task with templated params
+    setup: fourty.four({{ index .Args 0 }}, {{ index .Args 1 }})
+    command: true


### PR DESCRIPTION
My original use case was calling a setup task with some of the arguments passed into the first task.